### PR TITLE
feat: multi-author fix mode, internal doc links, URL skip fix

### DIFF
--- a/tomte/cli.py
+++ b/tomte/cli.py
@@ -79,12 +79,17 @@ def check_copyright(author: Tuple[str, ...], exclude_part: Tuple[str, ...], scan
     "--http-skips", "-n", multiple=True, help="Http urls to skip."
 )
 @click.option("--url-skips", "-u", multiple=True, help="Urls to skip.")
+@click.option(
+    "--check-internal", is_flag=True, default=False,
+    help="Also validate internal doc links, anchors, and images.",
+)
 def check_doc_links(
     http_skips: Tuple[str, ...],
     url_skips: Tuple[str, ...],
+    check_internal: bool,
 ) -> None:
     """Check doc links on all the doc .md files."""
-    check_doc_links_main(http_skips, url_skips)
+    check_doc_links_main(http_skips, url_skips, check_internal=check_internal)
 
 
 @click.command()

--- a/tomte/tools/check_copyright.py
+++ b/tomte/tools/check_copyright.py
@@ -36,7 +36,7 @@ import subprocess  # nosec
 import sys
 from datetime import datetime
 from pathlib import Path
-from typing import Dict, Iterator, Optional, Set, Tuple, cast
+from typing import Dict, Iterator, List, Optional, Set, Tuple, cast
 
 BIRTH_YEAR = 2021
 CURRENT_YEAR = datetime.now().year
@@ -235,11 +235,19 @@ def _validate_years(
     return check_info
 
 
-def fix_header(check_info: Dict) -> bool:
+def fix_header(
+    check_info: Dict,
+    authors: Optional[Tuple[str, ...]] = None,
+) -> bool:
     """Fix corrupt headers.
 
-    Only supports single-author (Valory AG) headers.
-    Multi-author fix mode is not supported.
+    Supports both single-author and multi-author headers.
+    For multi-author: updates primary author year, preserves secondary lines.
+    For secondary-only files: adds a primary author copyright line.
+
+    :param check_info: check result dict from check_copyright.
+    :param authors: tuple of author names. First is primary.
+    :return: True if the file was updated.
     """
 
     path = cast(Path, check_info.get("path"))
@@ -248,6 +256,52 @@ def fix_header(check_info: Dict) -> bool:
     is_update_needed = False
     missing_header = False
 
+    if authors and len(authors) > 1:
+        # Multi-author fix mode
+        primary_author = authors[0]
+        header_type = check_info.get("header_type", "")
+        secondary_lines: List[str] = check_info.get("secondary_lines", [])
+        header_regex = check_info.get("header_regex")
+
+        if header_type == "secondary_only":
+            # File has only secondary author(s) — add primary author line
+            mod_year = check_info.get("last_modification", get_modification_date(path)).year
+            copyright_string = f"#   Copyright {mod_year} {primary_author}"
+            for line in secondary_lines:
+                copyright_string += f"\n{line}"
+            is_update_needed = True
+
+        elif header_type in ("mixed", "primary_only"):
+            error_code = check_info.get("error_code")
+            if error_code in (ErrorTypes.END_YEAR_WRONG, ErrorTypes.END_YEAR_MISSING):
+                copyright_string = "#   Copyright {start}-{end} {author}".format(
+                    start=check_info["start_year"],
+                    end=check_info["last_modification"].year,
+                    author=primary_author,
+                )
+                for line in secondary_lines:
+                    copyright_string += f"\n{line}"
+                is_update_needed = True
+            elif error_code == ErrorTypes.START_YEAR_GT_END_YEAR:
+                copyright_string = "#   Copyright {end}-{start} {author}".format(
+                    start=check_info["start_year"],
+                    end=check_info["last_modification"].year,
+                    author=primary_author,
+                )
+                for line in secondary_lines:
+                    copyright_string += f"\n{line}"
+                is_update_needed = True
+
+        if is_update_needed and header_regex:
+            new_header = HEADER_TEMPLATE.format(copyright_string=copyright_string)
+            if SHEBANG in content:
+                new_header = SHEBANG + "\n" + new_header
+            updated_content = header_regex.sub(new_header, content)
+            path.write_text(updated_content)
+
+        return is_update_needed
+
+    # Single-author fix mode
     if "error_code" not in check_info:
         copyright_string = "#   Copyright {start_year}-{end_year} Valory AG".format(
             start_year=BIRTH_YEAR,
@@ -291,14 +345,23 @@ def fix_header(check_info: Dict) -> bool:
     return is_update_needed
 
 
-def update_headers(files: Iterator[Path]) -> None:
-    """Update headers (single-author mode only)."""
+def update_headers(
+    files: Iterator[Path],
+    authors: Optional[Tuple[str, ...]] = None,
+) -> None:
+    """Update headers.
+
+    :param files: iterator of file paths to check.
+    :param authors: tuple of author names. First is primary. If multiple,
+        enables multi-author fix mode.
+    """
 
     needs_update = []
+    authors_tuple = authors if authors and len(authors) > 1 else None
 
     for path in files:
         print("Checking {}".format(path))
-        check_data = check_copyright(path)
+        check_data = check_copyright(path, authors=authors_tuple, fix_mode=True)
         if not check_data["check"]:
             check_data["path"] = path
             needs_update.append(check_data)
@@ -308,7 +371,7 @@ def update_headers(files: Iterator[Path]) -> None:
         cannot_update = []
         for check_data in needs_update:
             print("Updating {}".format(check_data["path"]))
-            if not fix_header(check_data):
+            if not fix_header(check_data, authors=authors):
                 cannot_update.append(check_data)
 
         if len(cannot_update) > 0:
@@ -318,7 +381,11 @@ def update_headers(files: Iterator[Path]) -> None:
         print("No update needed.")
 
 
-def check_copyright(file: Path, authors: Optional[Tuple[str, ...]] = None) -> Dict:
+def check_copyright(
+    file: Path,
+    authors: Optional[Tuple[str, ...]] = None,
+    fix_mode: bool = False,
+) -> Dict:
     """
     Given a file, check if the header stuff is in place.
 
@@ -327,22 +394,24 @@ def check_copyright(file: Path, authors: Optional[Tuple[str, ...]] = None) -> Di
 
     :param file: the file to check.
     :param authors: tuple of allowed author names. If None, uses default single-author regex.
+    :param fix_mode: if True, returns extra metadata for fix_header and enables
+        end-year checking on secondary authors to detect files needing primary author.
     :return: True if the file is compliant with the checks, False otherwise.
     """
     content = file.read_text()
 
     if authors is not None and len(authors) > 1:
-        # Multi-author: validate that the header structure is correct,
-        # then check years on the primary author's copyright line only.
-        # Secondary (historical) authors are accepted as-is.
         header_regex = _build_multi_author_header_regex(authors)
         match = header_regex.match(content)
         if match is None:
             return {"check": False, "message": "Invalid copyright header."}
 
         primary_author = authors[0]
-        primary_result = None
-        last_secondary_result = None
+        secondary_lines: List[str] = []
+        primary_years = None  # (start_year, end_year) or None
+        secondary_years_list = []  # [(start, end, author_line_str), ...]
+
+        # First pass: collect all copyright lines
         for line_match in COPYRIGHT_LINE_REGEX.finditer(match.group(0)):
             line_author = line_match.group(4).strip()
             year_string = line_match.group(1)
@@ -352,27 +421,57 @@ def check_copyright(file: Path, authors: Optional[Tuple[str, ...]] = None) -> Di
                 start_year, end_year = int(year_string), None
 
             if line_author == primary_author:
-                primary_result = _validate_years(
-                    file, START_YEARS, start_year, end_year
-                )
-                if not primary_result["check"]:
-                    return primary_result
+                primary_years = (start_year, end_year)
             else:
-                # Secondary (historical) authors: validate against broader
-                # year range, matching open-aea's behavior for FetchAI files
-                last_secondary_result = _validate_years(
-                    file, START_YEARS_HISTORICAL, start_year, end_year,
-                    check_end_year=False,
-                )
-                if not last_secondary_result["check"]:
-                    return last_secondary_result
+                secondary_lines.append(line_match.group(0).strip())
+                secondary_years_list.append((start_year, end_year))
 
-        # If the primary author was found, return its validation result.
-        # If only secondary (historical) authors are present, return their result.
-        if primary_result is not None:
+        has_primary = primary_years is not None
+        metadata = {
+            "secondary_lines": secondary_lines,
+            "header_regex": header_regex,
+        }
+
+        # Second pass: validate
+        if has_primary:
+            primary_result = _validate_years(
+                file, START_YEARS, primary_years[0], primary_years[1]
+            )
+            primary_result.update(metadata)
+            primary_result["header_type"] = "mixed" if secondary_lines else "primary_only"
+            if not primary_result["check"]:
+                return primary_result
+
+        for (s_start, s_end) in secondary_years_list:
+            # Only check end year on secondary authors in fix mode when
+            # there is no primary author (to detect files needing one added).
+            # In mixed files, secondary lines are frozen historical data.
+            secondary_result = _validate_years(
+                file, START_YEARS_HISTORICAL, s_start, s_end,
+                check_end_year=fix_mode and not has_primary,
+            )
+            if not secondary_result["check"]:
+                secondary_result.update(metadata)
+                secondary_result["header_type"] = "secondary_only" if not has_primary else "mixed"
+                return secondary_result
+
+        # All validations passed
+        if has_primary:
+            primary_result.update(metadata)
             return primary_result
-        if last_secondary_result is not None:
-            return last_secondary_result
+
+        # Secondary-only file that passed validation
+        last_secondary_result = _validate_years(
+            file, START_YEARS_HISTORICAL,
+            secondary_years_list[-1][0], secondary_years_list[-1][1],
+            check_end_year=False,
+        )
+        last_secondary_result.update(metadata)
+        last_secondary_result["header_type"] = "secondary_only"
+        if fix_mode and last_secondary_result["check"]:
+            last_secondary_result["check"] = False
+            last_secondary_result["message"] = "Missing primary author copyright line."
+        return last_secondary_result
     else:
         match = HEADER_REGEX.match(content)
         if match is not None:
@@ -428,15 +527,6 @@ def main(
     :param scan_paths: custom paths to scan. If None, uses default (packages/{author}, tests, scripts).
     """
 
-    if fix and len(authors) > 1:
-        print(
-            "Error: fix mode is not supported with multiple authors. "
-            "Multi-author headers contain historical copyright lines that "
-            "should not be auto-modified.",
-            file=sys.stderr,
-        )
-        sys.exit(1)
-
     primary_author = authors[0]
     exclude_files = {Path("scripts", "whitelist.py")}
 
@@ -474,6 +564,6 @@ def main(
     python_files_filtered = filter(_file_filter, python_files)
     authors_tuple = authors if len(authors) > 1 else None
     if fix:
-        update_headers(python_files_filtered)
+        update_headers(python_files_filtered, authors=authors)
     else:
         run_check(python_files_filtered, authors=authors_tuple)

--- a/tomte/tools/check_copyright.py
+++ b/tomte/tools/check_copyright.py
@@ -261,11 +261,23 @@ def fix_header(
         primary_author = authors[0]
         header_type = check_info.get("header_type", "")
         secondary_lines: List[str] = check_info.get("secondary_lines", [])
-        header_regex = check_info.get("header_regex")
+        header_regex = _build_multi_author_header_regex(authors)
+
+        if header_type == "":
+            # No header_type means no valid header was found (match was None).
+            # Insert a fresh header with primary author only.
+            mod_year = get_modification_date(path).year
+            copyright_string = f"#   Copyright {mod_year} {primary_author}"
+            new_header = HEADER_TEMPLATE.format(copyright_string=copyright_string)
+            new_header = SHEBANG + "\n" + new_header
+            if content != "":
+                new_header += "\n\n"
+            path.write_text(new_header + content)
+            return True
 
         if header_type == "secondary_only":
             # File has only secondary author(s) — add primary author line
-            mod_year = check_info.get("last_modification", get_modification_date(path)).year
+            mod_year = check_info["last_modification"].year
             copyright_string = f"#   Copyright {mod_year} {primary_author}"
             for line in secondary_lines:
                 copyright_string += f"\n{line}"
@@ -292,7 +304,7 @@ def fix_header(
                     copyright_string += f"\n{line}"
                 is_update_needed = True
 
-        if is_update_needed and header_regex:
+        if is_update_needed:
             new_header = HEADER_TEMPLATE.format(copyright_string=copyright_string)
             if SHEBANG in content:
                 new_header = SHEBANG + "\n" + new_header
@@ -409,7 +421,7 @@ def check_copyright(
         primary_author = authors[0]
         secondary_lines: List[str] = []
         primary_years = None  # (start_year, end_year) or None
-        secondary_years_list = []  # [(start, end, author_line_str), ...]
+        secondary_years_list = []  # [(start_year, end_year), ...]
 
         # First pass: collect all copyright lines
         for line_match in COPYRIGHT_LINE_REGEX.finditer(match.group(0)):
@@ -429,7 +441,6 @@ def check_copyright(
         has_primary = primary_years is not None
         metadata = {
             "secondary_lines": secondary_lines,
-            "header_regex": header_regex,
         }
 
         # Second pass: validate

--- a/tomte/tools/check_copyright.py
+++ b/tomte/tools/check_copyright.py
@@ -454,12 +454,12 @@ def check_copyright(
                 return primary_result
 
         for (s_start, s_end) in secondary_years_list:
-            # Only check end year on secondary authors in fix mode when
-            # there is no primary author (to detect files needing one added).
-            # In mixed files, secondary lines are frozen historical data.
+            # Secondary author lines are frozen historical data — never
+            # validate their end year. For secondary-only files needing a
+            # primary author, the post-loop block handles detection.
             secondary_result = _validate_years(
                 file, START_YEARS_HISTORICAL, s_start, s_end,
-                check_end_year=fix_mode and not has_primary,
+                check_end_year=False,
             )
             if not secondary_result["check"]:
                 secondary_result.update(metadata)

--- a/tomte/tools/check_doc_links.py
+++ b/tomte/tools/check_doc_links.py
@@ -132,9 +132,9 @@ def check_file(
 
 
 LINK_PATTERN_HTML = re.compile(r'(?<=<a href=")[^"]*')
+LINK_PATTERN_MD = re.compile(r"\[([^\]]+)\]\(([^)]+)\)")
 IMAGE_PATTERN = re.compile(r'<img[^>]+src="([^">]+)"')
 ANCHOR_TAG_PATTERN = re.compile(r"<a.*?>(.+?)</a>")
-RELATIVE_PATH_PREFIX = "../"
 DOCS_DIR = Path("docs")
 
 
@@ -150,8 +150,8 @@ def _check_internal_links(
     """Check internal links in a documentation file.
 
     Validates:
-    - HTML <a href="..."> links point to existing doc files
-    - Anchor fragments (#section) exist in target files
+    - HTML <a href="..."> and markdown [text](url) links point to existing doc files
+    - Anchor fragments (#section) exist in target files (heuristic: substring match)
     - <img src="..."> images exist on disk
     - External <a> tags have target="_blank"
 
@@ -161,16 +161,27 @@ def _check_internal_links(
     """
     errors: List[str] = []
     text = file.read_text(encoding="utf-8")
-    is_index = file == DOCS_DIR / "index.md"
 
     # Check HTML <a href="..."> links
     for match in LINK_PATTERN_HTML.finditer(text):
         url = match.group()
         if _is_external_url(url):
             continue
-        # Validate internal relative link
         try:
-            _validate_internal_url(file, url, all_docs_files, is_index)
+            _validate_internal_url(file, url, all_docs_files)
+        except ValueError as e:
+            errors.append(str(e))
+
+    # Check markdown [text](url) links
+    for match in LINK_PATTERN_MD.finditer(text):
+        url = match.group(2).strip()
+        if _is_external_url(url):
+            continue
+        if url.startswith("#"):
+            # Same-file anchor — skip (would need heading parsing)
+            continue
+        try:
+            _validate_internal_url(file, url, all_docs_files)
         except ValueError as e:
             errors.append(str(e))
 
@@ -179,12 +190,12 @@ def _check_internal_links(
         src = match.group(1)
         if _is_external_url(src):
             continue
-        if src.startswith(RELATIVE_PATH_PREFIX):
-            img_path = DOCS_DIR / src[len(RELATIVE_PATH_PREFIX):]
-            if not img_path.exists():
-                errors.append(
-                    f"Image path={img_path} in file={file} not found!"
-                )
+        # Resolve relative to the file's parent directory
+        img_path = (file.parent / src).resolve()
+        if not img_path.exists():
+            errors.append(
+                f"Image path={src} in file={file} not found!"
+            )
 
     # Check external <a> tags have target="_blank"
     for match in ANCHOR_TAG_PATTERN.finditer(text):
@@ -206,51 +217,57 @@ def _validate_internal_url(
     file: Path,
     url: str,
     all_docs_files: Set[Path],
-    is_index: bool = False,
 ) -> None:
     """Validate an internal relative URL points to an existing doc file.
+
+    Resolves the URL relative to the source file's parent directory.
 
     :param file: the source file.
     :param url: the relative URL to validate.
     :param all_docs_files: set of all doc file paths.
-    :param is_index: whether the source file is the index.
     :raises ValueError: if the link is invalid.
     """
-    if not url.startswith(RELATIVE_PATH_PREFIX) and not is_index:
-        if url.startswith("#"):
-            return
-        raise ValueError(
-            f"Invalid relative path={url} in file={file}!"
-        )
-
-    if ".md" in url:
-        raise ValueError(
-            f"Path={url} contains invalid `.md` extension in file={file}!"
-        )
-
     hash_index = url.find("#")
-    if hash_index == -1:
-        n_url = url[len(RELATIVE_PATH_PREFIX):] if not is_index else url
-        n_url = n_url.rstrip("/")
-        target_path = DOCS_DIR / f"{n_url}.md"
-        anchor = ""
-    else:
-        path_part = url[:hash_index]
-        n_url = path_part[len(RELATIVE_PATH_PREFIX):] if not is_index else path_part
-        n_url = n_url.rstrip("/")
-        target_path = DOCS_DIR / f"{n_url}.md"
-        anchor = url[hash_index:]
+    if hash_index == 0:
+        # Pure anchor link (#section) — skip
+        return
 
-    if target_path not in all_docs_files:
+    if hash_index != -1:
+        path_part = url[:hash_index]
+        anchor = url[hash_index:]
+    else:
+        path_part = url
+        anchor = ""
+
+    path_part = path_part.rstrip("/")
+
+    # Resolve relative to source file's directory
+    if path_part.endswith(".md"):
+        target_path = (file.parent / path_part).resolve()
+    else:
+        target_path = (file.parent / f"{path_part}.md").resolve()
+
+    # Normalize to project-relative for comparison with all_docs_files
+    try:
+        target_relative = target_path.relative_to(Path.cwd())
+    except ValueError:
         raise ValueError(
-            f"Path={target_path} found in file={file} does not exist!"
+            f"Path={url} in file={file} resolves outside project root!"
+        )
+
+    if target_relative not in all_docs_files:
+        raise ValueError(
+            f"Path={target_relative} found in file={file} does not exist!"
         )
 
     if anchor:
+        # Heuristic: check if the anchor string appears anywhere in the target file.
+        # This is a naive substring match — it may match inside code blocks or comments.
+        # For strict validation, heading parsing would be needed.
         target_text = target_path.read_text(encoding="utf-8")
         if anchor not in target_text:
             raise ValueError(
-                f"Anchor={anchor} not found in file={target_path} (linked from {file})!"
+                f"Anchor={anchor} not found in file={target_relative} (linked from {file})!"
             )
 
 
@@ -330,8 +347,7 @@ def main(
         internal_errors: Dict[str, List[str]] = {}
         if check_internal and DOCS_DIR.exists():
             all_docs_files = set(DOCS_DIR.rglob("*.md"))
-            docs_top_level = list(DOCS_DIR.glob("*.md"))
-            for doc_file in docs_top_level:
+            for doc_file in sorted(all_docs_files):
                 print(f"Checking internal links in {doc_file}...")
                 errs = _check_internal_links(doc_file, all_docs_files)
                 if errs:

--- a/tomte/tools/check_doc_links.py
+++ b/tomte/tools/check_doc_links.py
@@ -132,7 +132,9 @@ def check_file(
 
 
 LINK_PATTERN_HTML = re.compile(r'(?<=<a href=")[^"]*')
-LINK_PATTERN_MD = re.compile(r"\[([^\]]+)\]\(([^)]+)\)")
+# Negative lookbehind (?<!!) excludes markdown image syntax ![alt](path)
+LINK_PATTERN_MD = re.compile(r"(?<!!)\[([^\]]+)\]\(([^)]+)\)")
+MD_IMAGE_PATTERN = re.compile(r"!\[([^\]]+)\]\(([^)]+)\)")
 IMAGE_PATTERN = re.compile(r'<img[^>]+src="([^">]+)"')
 ANCHOR_TAG_PATTERN = re.compile(r"<a.*?>(.+?)</a>")
 DOCS_DIR = Path("docs")
@@ -185,12 +187,21 @@ def _check_internal_links(
         except ValueError as e:
             errors.append(str(e))
 
-    # Check <img src="..."> tags
+    # Check HTML <img src="..."> and markdown ![alt](path) images
     for match in IMAGE_PATTERN.finditer(text):
         src = match.group(1)
         if _is_external_url(src):
             continue
-        # Resolve relative to the file's parent directory
+        img_path = (file.parent / src).resolve()
+        if not img_path.exists():
+            errors.append(
+                f"Image path={src} in file={file} not found!"
+            )
+
+    for match in MD_IMAGE_PATTERN.finditer(text):
+        src = match.group(2).strip()
+        if _is_external_url(src):
+            continue
         img_path = (file.parent / src).resolve()
         if not img_path.exists():
             errors.append(

--- a/tomte/tools/check_doc_links.py
+++ b/tomte/tools/check_doc_links.py
@@ -23,10 +23,11 @@
 
 import re
 import sys
+import xml.etree.ElementTree as ET  # nosec
 from concurrent.futures import ThreadPoolExecutor
 from itertools import chain
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Set
 
 import requests
 import urllib3  # type: ignore
@@ -51,7 +52,7 @@ HTTP_SKIPS = [
 # Special links that are allowed to respond with an error status
 # Remove non-url-allowed characters like ` before adding them here
 URL_SKIPS = [
-    "https://gateway.autonolas.tech/ipfs/<hash>,",  # non link (400)
+    "https://gateway.autonolas.tech/ipfs/<hash>",  # non link (400)
     "https://github.com/valory-xyz/open-autonomy/trunk/infrastructure",  # svn link (404)
     "http://host.docker.internal:8545",  # internal (ERR_NAME_NOT_RESOLVED)
 ]
@@ -130,9 +131,133 @@ def check_file(
     }
 
 
+LINK_PATTERN_HTML = re.compile(r'(?<=<a href=")[^"]*')
+IMAGE_PATTERN = re.compile(r'<img[^>]+src="([^">]+)"')
+ANCHOR_TAG_PATTERN = re.compile(r"<a.*?>(.+?)</a>")
+RELATIVE_PATH_PREFIX = "../"
+DOCS_DIR = Path("docs")
+
+
+def _is_external_url(url: str) -> bool:
+    """Check if a URL is external."""
+    return url.startswith("https://") or url.startswith("http://")
+
+
+def _check_internal_links(
+    file: Path,
+    all_docs_files: Set[Path],
+) -> List[str]:
+    """Check internal links in a documentation file.
+
+    Validates:
+    - HTML <a href="..."> links point to existing doc files
+    - Anchor fragments (#section) exist in target files
+    - <img src="..."> images exist on disk
+    - External <a> tags have target="_blank"
+
+    :param file: path to the markdown file to check.
+    :param all_docs_files: set of all documentation file paths.
+    :return: list of error messages.
+    """
+    errors: List[str] = []
+    text = file.read_text(encoding="utf-8")
+    is_index = file == DOCS_DIR / "index.md"
+
+    # Check HTML <a href="..."> links
+    for match in LINK_PATTERN_HTML.finditer(text):
+        url = match.group()
+        if _is_external_url(url):
+            continue
+        # Validate internal relative link
+        try:
+            _validate_internal_url(file, url, all_docs_files, is_index)
+        except ValueError as e:
+            errors.append(str(e))
+
+    # Check <img src="..."> tags
+    for match in IMAGE_PATTERN.finditer(text):
+        src = match.group(1)
+        if _is_external_url(src):
+            continue
+        if src.startswith(RELATIVE_PATH_PREFIX):
+            img_path = DOCS_DIR / src[len(RELATIVE_PATH_PREFIX):]
+            if not img_path.exists():
+                errors.append(
+                    f"Image path={img_path} in file={file} not found!"
+                )
+
+    # Check external <a> tags have target="_blank"
+    for match in ANCHOR_TAG_PATTERN.finditer(text):
+        try:
+            tag = ET.fromstring(match.group())  # nosec
+        except ET.ParseError:
+            continue
+        href = tag.attrib.get("href")
+        target = tag.attrib.get("target")
+        if href and _is_external_url(href) and target != "_blank":
+            errors.append(
+                f"External link href={href} in file={file} missing target=\"_blank\"."
+            )
+
+    return errors
+
+
+def _validate_internal_url(
+    file: Path,
+    url: str,
+    all_docs_files: Set[Path],
+    is_index: bool = False,
+) -> None:
+    """Validate an internal relative URL points to an existing doc file.
+
+    :param file: the source file.
+    :param url: the relative URL to validate.
+    :param all_docs_files: set of all doc file paths.
+    :param is_index: whether the source file is the index.
+    :raises ValueError: if the link is invalid.
+    """
+    if not url.startswith(RELATIVE_PATH_PREFIX) and not is_index:
+        if url.startswith("#"):
+            return
+        raise ValueError(
+            f"Invalid relative path={url} in file={file}!"
+        )
+
+    if ".md" in url:
+        raise ValueError(
+            f"Path={url} contains invalid `.md` extension in file={file}!"
+        )
+
+    hash_index = url.find("#")
+    if hash_index == -1:
+        n_url = url[len(RELATIVE_PATH_PREFIX):] if not is_index else url
+        n_url = n_url.rstrip("/")
+        target_path = DOCS_DIR / f"{n_url}.md"
+        anchor = ""
+    else:
+        path_part = url[:hash_index]
+        n_url = path_part[len(RELATIVE_PATH_PREFIX):] if not is_index else path_part
+        n_url = n_url.rstrip("/")
+        target_path = DOCS_DIR / f"{n_url}.md"
+        anchor = url[hash_index:]
+
+    if target_path not in all_docs_files:
+        raise ValueError(
+            f"Path={target_path} found in file={file} does not exist!"
+        )
+
+    if anchor:
+        target_text = target_path.read_text(encoding="utf-8")
+        if anchor not in target_text:
+            raise ValueError(
+                f"Anchor={anchor} not found in file={target_path} (linked from {file})!"
+            )
+
+
 def main(
     http_skips: Optional[List[str]] = None,
     url_skips: Optional[List[str]] = None,
+    check_internal: bool = False,
 ) -> None:  # pylint: disable=too-many-locals
     """Check for broken or HTTP links"""
     all_md_files = [
@@ -201,7 +326,25 @@ def main(
                 f"Found HTTP urls in the docs:\n{http_links_str}\nTry to use HTTPS equivalent urls or add them to 'http_skips' if not possible"
             )
 
-        if broken_links or http_links:
+        # Internal link checks (opt-in)
+        internal_errors: Dict[str, List[str]] = {}
+        if check_internal and DOCS_DIR.exists():
+            all_docs_files = set(DOCS_DIR.rglob("*.md"))
+            docs_top_level = list(DOCS_DIR.glob("*.md"))
+            for doc_file in docs_top_level:
+                print(f"Checking internal links in {doc_file}...")
+                errs = _check_internal_links(doc_file, all_docs_files)
+                if errs:
+                    internal_errors[str(doc_file)] = errs
+
+        if internal_errors:
+            internal_str = "\n".join(
+                f"{fname}: {errs}"
+                for fname, errs in internal_errors.items()
+            )
+            print(f"Found internal link errors:\n{internal_str}")
+
+        if broken_links or http_links or internal_errors:
             sys.exit(1)
 
         print("OK")


### PR DESCRIPTION
## Summary
- **Multi-author fix mode**: `tomte format-copyright --author "Valory AG" --author "Fetch.AI Limited"` now works. Updates primary author year while preserving secondary lines. Converts secondary-only files to mixed headers.
- **Internal doc link checking**: New `--check-internal` flag on `tomte check-doc-links`. Validates internal relative links, anchor fragments (#section), image paths, and target="_blank" on external `<a>` tags.
- **Bug fix**: Removed trailing comma from default URL_SKIPS entry (`ipfs/<hash>,` → `ipfs/<hash>`).

These changes enable full migration of `scripts/check_copyright_notice.py`, `scripts/check_doc_links.py`, and `scripts/freeze_dependencies.py` from both open-aea and open-autonomy to tomte CLI commands.

## Test plan
- [ ] Verify multi-author fix: FetchAI-only → adds Valory line
- [ ] Verify multi-author fix: Mixed outdated → updates Valory year, preserves FetchAI
- [ ] Verify single-author backward compatibility
- [ ] Verify `--check-internal` validates relative links, anchors, images
- [ ] Verify `--check-internal` is opt-in (no change without flag)
- [ ] Verify URL skip bug fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)