### PR TITLE
chore: add CI workflow with stub test and all-checks-passed gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,27 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  stub-test:
+    name: Stub test
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "stub test — replace with real checks"
+
+  all-checks-passed:
+    name: All checks passed
+    if: always()
+    needs:
+      - stub-test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify no dependency failed or was cancelled
+        run: |
+          if [[ "${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped') }}" == "true" ]]; then
+            echo "One or more required jobs did not succeed"
+            exit 1
+          fi


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/ci.yml` with a `stub-test` placeholder job and an `all-checks-passed` meta-job (`needs: [stub-test]`, `if: always()`, fails on failure/cancel/skip)
- Enables a single aggregate gate branch protection can point at; update the meta-job's `needs` list when adding real checks rather than editing branch protection

## Test plan
- [x] CI runs on this PR
- [x] `All checks passed` context is green
- [x] After merge, configure branch protection on `main` to require `All checks passed`

Generated with Claude Code
