### PR TITLE
release: rename PyPI token secret to canonical PYPI_API_TOKEN

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,6 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__
-          password: ${{ secrets.PYPI_TOKEN }}
+          password: ${{ secrets.PYPI_API_TOKEN }}
           skip-existing: true
           packages-dir: dist/


### PR DESCRIPTION
## Summary

- Updates `release.yml` to reference `secrets.PYPI_API_TOKEN` instead of the now-deleted `secrets.PYPI_TOKEN`.
- The repo Secret was rotated and renamed to the canonical `PYPI_API_TOKEN` on 2026-05-15. Without this one-line YAML change the next release run would pass an empty password to `pypa/gh-action-pypi-publish` and fail upload.

## Why now

Per the [Valory secrets policy](https://github.com/valory-xyz/central-command/blob/main/policies/secrets.md), the canonical name for PyPI publish tokens is `PYPI_API_TOKEN`, and the rename of a variant-named Secret MUST land together with the workflow update that references it. The Secret rotation already happened; this PR closes the loop.

## Test plan

- [ ] Cut a release (or run `release.yml` against a tag) once merged and confirm the `Publish open-autonomy Framework to PyPI` step reaches the upload phase without a 403/empty-token error.
- [ ] Confirm `secrets.PYPI_TOKEN` is no longer referenced in any workflow file (`grep -rn PYPI_TOKEN .github/`).

Generated with [Claude Code](https://claude.com/claude-code)